### PR TITLE
v6.1.24 - no more hugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,17 @@ image-set:
 	/usr/bin/sed -i '' "s|$$current|$$next|g" kustomize/deployment.yaml && \
 	echo "Image repo $$next set in deployment, chart and kustomize"
 
-release:
+release-app:
 	git tag $(VERSION)
 	git push origin $(VERSION)
+
+release-oci:
 	git tag release/$(VERSION)
 	git push origin release/$(VERSION)
 
-push-tag: version-set release
+# Careful
+push-tag: version-set release-app
+	echo "Now go check on the build, and when it's finished run: make release-oci"
 
 push-config:
 	flux push artifact $(GHCR_IMAGE_REPO)/deploy:$(VERSION) \

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 6.1.23
-appVersion: 6.1.23
+version: 6.1.24
+appVersion: 6.1.24
 name: podinfo
 engine: gotpl
 description: Podinfo Helm chart for Kubernetes

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -8,7 +8,7 @@ backends: []
 
 image:
   repository: ghcr.io/kingdonb/podinfo
-  tag: 6.1.23
+  tag: 6.1.24
   pullPolicy: IfNotPresent
 
 ui:

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -8,7 +8,7 @@ backends: []
 
 image:
   repository: ghcr.io/kingdonb/podinfo
-  tag: 6.1.23
+  tag: 6.1.24
   pullPolicy: IfNotPresent
 
 ui:

--- a/cue/main.cue
+++ b/cue/main.cue
@@ -10,7 +10,7 @@ app: podinfo.#Application & {
 			name:      "podinfo"
 			namespace: "default"
 		}
-		image: tag: "6.1.23"
+		image: tag: "6.1.24"
 		resources: requests: {
 			cpu:    "100m"
 			memory: "16Mi"

--- a/deploy/bases/backend/deployment.yaml
+++ b/deploy/bases/backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: ghcr.io/kingdonb/podinfo:6.1.23
+        image: ghcr.io/kingdonb/podinfo:6.1.24
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/bases/frontend/deployment.yaml
+++ b/deploy/bases/frontend/deployment.yaml
@@ -41,8 +41,6 @@ spec:
         - --port-metrics=9797
         - --level=info
         - --backend-url=http://backend:9898/echo
-        # - --ui-logo=https://raw.githubusercontent.com/stefanprodan/podinfo/gh-pages/cuddle_clap.gif
-        - --ui-logo=https://raw.githubusercontent.com/stefanprodan/podinfo/gh-pages/cuddle_bunny.gif
         - --cache-server=cache:6379
         env:
         - name: PODINFO_UI_COLOR

--- a/deploy/bases/frontend/deployment.yaml
+++ b/deploy/bases/frontend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: ghcr.io/kingdonb/podinfo:6.1.23
+        image: ghcr.io/kingdonb/podinfo:6.1.24
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/webapp/backend/deployment.yaml
+++ b/deploy/webapp/backend/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: webapp
       containers:
       - name: backend
-        image: ghcr.io/kingdonb/podinfo:6.1.23
+        image: ghcr.io/kingdonb/podinfo:6.1.24
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/webapp/frontend/deployment.yaml
+++ b/deploy/webapp/frontend/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: webapp
       containers:
       - name: frontend
-        image: ghcr.io/kingdonb/podinfo:6.1.23
+        image: ghcr.io/kingdonb/podinfo:6.1.24
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "6.1.23"
+var VERSION = "6.1.24"
 var REVISION = "unknown"


### PR DESCRIPTION
Let's separate building and pushing an app image from building and pushing OCI manifests, since they should not be done back-to-back.

Building and pushing OCI manifests is typically much faster than the Docker Build performed when building and pushing an app image. So if these two fire at the same time, the manifests will likely be deploying before the image is ready! Bad...

These are all concerns for CI to figure out. Flux just deploys the latest according to policy. These policies can be much more straightforward now with Flux's new OCI support.

Ref:
* https://github.com/weaveworks/vscode-gitops-tools/pull/358
* https://github.com/fluxcd/flux2/pull/2856